### PR TITLE
Remove floating point usage from PDMC

### DIFF
--- a/components/TARGET_PSA/services/attestation/qcbor/src/qcbor_decode.c
+++ b/components/TARGET_PSA/services/attestation/qcbor/src/qcbor_decode.c
@@ -201,7 +201,9 @@ static const uint16_t spBuiltInTagMap[] = {
    CBOR_TAG_POS_BIGNUM, // See TAG_MAPPER_FIRST_FOUR
    CBOR_TAG_NEG_BIGNUM, // See TAG_MAPPER_FIRST_FOUR
    CBOR_TAG_FRACTION,
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
    CBOR_TAG_BIGFLOAT,
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
    CBOR_TAG_COSE_ENCRYPTO,
    CBOR_TAG_COSE_MAC0,
    CBOR_TAG_COSE_SIGN1,
@@ -471,6 +473,7 @@ inline static QCBORError DecodeInteger(int nMajorType, uint64_t uNumber, QCBORIt
 #error QCBOR_TYPE_BREAK macro value wrong
 #endif
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 #if QCBOR_TYPE_DOUBLE != DOUBLE_PREC_FLOAT
 #error QCBOR_TYPE_DOUBLE macro value wrong
 #endif
@@ -478,6 +481,7 @@ inline static QCBORError DecodeInteger(int nMajorType, uint64_t uNumber, QCBORIt
 #if QCBOR_TYPE_FLOAT != SINGLE_PREC_FLOAT
 #error QCBOR_TYPE_FLOAT macro value wrong
 #endif
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 /*
  Decode true, false, floats, break...
@@ -498,7 +502,7 @@ inline static QCBORError DecodeSimple(uint8_t uAdditionalInfo, uint64_t uNumber,
       case ADDINFO_RESERVED3:  // 30
          nReturn = QCBOR_ERR_UNSUPPORTED;
          break;
-
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
       case HALF_PREC_FLOAT:
          pDecodedItem->val.dfnum = IEEE754_HalfToDouble((uint16_t)uNumber);
          pDecodedItem->uDataType = QCBOR_TYPE_DOUBLE;
@@ -511,6 +515,7 @@ inline static QCBORError DecodeSimple(uint8_t uAdditionalInfo, uint64_t uNumber,
          pDecodedItem->val.dfnum = UsefulBufUtil_CopyUint64ToDouble(uNumber);
          pDecodedItem->uDataType = QCBOR_TYPE_DOUBLE;
          break;
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
       case CBOR_SIMPLEV_FALSE: // 20
       case CBOR_SIMPLEV_TRUE:  // 21
@@ -633,6 +638,7 @@ static int DecodeDateEpoch(QCBORItem *pDecodedItem)
          pDecodedItem->val.epochDate.nSeconds = pDecodedItem->val.uint64;
          break;
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
       case QCBOR_TYPE_DOUBLE:
          {
             const double d = pDecodedItem->val.dfnum;
@@ -644,6 +650,7 @@ static int DecodeDateEpoch(QCBORItem *pDecodedItem)
             pDecodedItem->val.epochDate.fSecondsFraction = d - pDecodedItem->val.epochDate.nSeconds;
          }
          break;
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
       default:
          nReturn = QCBOR_ERR_BAD_OPT_TAG;

--- a/components/TARGET_PSA/services/attestation/qcbor/src/qcbor_decode.c
+++ b/components/TARGET_PSA/services/attestation/qcbor/src/qcbor_decode.c
@@ -201,9 +201,7 @@ static const uint16_t spBuiltInTagMap[] = {
    CBOR_TAG_POS_BIGNUM, // See TAG_MAPPER_FIRST_FOUR
    CBOR_TAG_NEG_BIGNUM, // See TAG_MAPPER_FIRST_FOUR
    CBOR_TAG_FRACTION,
-#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
    CBOR_TAG_BIGFLOAT,
-#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
    CBOR_TAG_COSE_ENCRYPTO,
    CBOR_TAG_COSE_MAC0,
    CBOR_TAG_COSE_SIGN1,
@@ -473,7 +471,6 @@ inline static QCBORError DecodeInteger(int nMajorType, uint64_t uNumber, QCBORIt
 #error QCBOR_TYPE_BREAK macro value wrong
 #endif
 
-#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 #if QCBOR_TYPE_DOUBLE != DOUBLE_PREC_FLOAT
 #error QCBOR_TYPE_DOUBLE macro value wrong
 #endif
@@ -481,7 +478,6 @@ inline static QCBORError DecodeInteger(int nMajorType, uint64_t uNumber, QCBORIt
 #if QCBOR_TYPE_FLOAT != SINGLE_PREC_FLOAT
 #error QCBOR_TYPE_FLOAT macro value wrong
 #endif
-#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 /*
  Decode true, false, floats, break...
@@ -514,6 +510,12 @@ inline static QCBORError DecodeSimple(uint8_t uAdditionalInfo, uint64_t uNumber,
       case DOUBLE_PREC_FLOAT:
          pDecodedItem->val.dfnum = UsefulBufUtil_CopyUint64ToDouble(uNumber);
          pDecodedItem->uDataType = QCBOR_TYPE_DOUBLE;
+         break;
+#else
+      case HALF_PREC_FLOAT:
+      case SINGLE_PREC_FLOAT:
+      case DOUBLE_PREC_FLOAT:
+         nReturn = QCBOR_ERR_UNSUPPORTED;
          break;
 #endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
@@ -649,6 +651,11 @@ static int DecodeDateEpoch(QCBORItem *pDecodedItem)
             pDecodedItem->val.epochDate.nSeconds = d; // Float to integer conversion happening here.
             pDecodedItem->val.epochDate.fSecondsFraction = d - pDecodedItem->val.epochDate.nSeconds;
          }
+         break;
+#else
+      case QCBOR_TYPE_DOUBLE:
+         nReturn = QCBOR_ERR_BAD_OPT_TAG;
+         goto Done;
          break;
 #endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 

--- a/components/TARGET_PSA/services/attestation/qcbor/test/qcbor_decode_tests.c
+++ b/components/TARGET_PSA/services/attestation/qcbor/test/qcbor_decode_tests.c
@@ -1503,7 +1503,7 @@ static uint8_t spDateTestInput[] = {
 
 };
 
-
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 // have to check float expected only to within an epsilon
 int CHECK_EXPECTED_DOUBLE(double val, double expected) {
 
@@ -1513,6 +1513,7 @@ int CHECK_EXPECTED_DOUBLE(double val, double expected) {
 
    return diff > 0.0000001;
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 
 int DateParseTest()
@@ -1561,6 +1562,7 @@ int DateParseTest()
       return -7;
    }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
    // Epoch date in float format with fractional seconds
    if((nCBORError = QCBORDecode_GetNext(&DCtx, &Item)))
       return -8;
@@ -1569,6 +1571,7 @@ int DateParseTest()
       CHECK_EXPECTED_DOUBLE(Item.val.epochDate.fSecondsFraction, 0.1 )) {
       return -9;
    }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
    // Epoch date float that is too large for our representation
    if(QCBORDecode_GetNext(&DCtx, &Item) != QCBOR_ERR_DATE_OVERFLOW) {
@@ -1688,7 +1691,9 @@ int OptTagParseTest()
    if(Item.uDataType != QCBOR_TYPE_ARRAY ||
       !QCBORDecode_IsTagged(&DCtx, &Item, 0x9192939495969798) ||
       QCBORDecode_IsTagged(&DCtx, &Item, 257) ||
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
       QCBORDecode_IsTagged(&DCtx, &Item, CBOR_TAG_BIGFLOAT) ||
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
       Item.val.uCount != 0) {
       return -9;
    }

--- a/components/TARGET_PSA/services/attestation/qcbor/test/qcbor_decode_tests.c
+++ b/components/TARGET_PSA/services/attestation/qcbor/test/qcbor_decode_tests.c
@@ -1691,9 +1691,7 @@ int OptTagParseTest()
    if(Item.uDataType != QCBOR_TYPE_ARRAY ||
       !QCBORDecode_IsTagged(&DCtx, &Item, 0x9192939495969798) ||
       QCBORDecode_IsTagged(&DCtx, &Item, 257) ||
-#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
       QCBORDecode_IsTagged(&DCtx, &Item, CBOR_TAG_BIGFLOAT) ||
-#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
       Item.val.uCount != 0) {
       return -9;
    }

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -75,10 +75,17 @@ int Timer::read_us()
     return read_high_resolution_us();
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 float Timer::read()
 {
     return (float)read_high_resolution_us() / 1000000.0f;
 }
+#else
+int Timer::read()
+{
+    return (int)read_high_resolution_us() / 1000000;
+}
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 int Timer::read_ms()
 {
@@ -112,9 +119,17 @@ void Timer::reset()
     core_util_critical_section_exit();
 }
 
+
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 Timer::operator float()
 {
     return read();
 }
+#else
+Timer::operator int()
+{
+    return read();
+}
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 } // namespace mbed

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -83,7 +83,7 @@ float Timer::read()
 #else
 int Timer::read()
 {
-    return (int)read_high_resolution_us() / 1000000;
+    return read_high_resolution_us() / 1000000;
 }
 #endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -74,7 +74,11 @@ public:
      *
      *  @returns    Time passed in seconds
      */
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
     float read();
+#else
+    int read();
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
     /** Get the time passed in milliseconds
      *
@@ -90,7 +94,11 @@ public:
 
     /** An operator shorthand for read()
      */
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
     operator float();
+#else
+    operator int();
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
     /** Get in a high resolution type the time passed in microseconds.
      *  Returns a 64 bit integer.

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -1128,7 +1128,7 @@ bool AT_CellularSMS::create_time(const char *time_string, time_t *time)
                &time_struct.tm_hour, &time_struct.tm_min, &time_struct.tm_sec, &sign, &gmt) == kNumberOfElements) {
         *time = mktime(&time_struct);
         // add timezone as seconds. gmt is in quarter of hours.
-        int x = (60 * 60 * gmt) / 4;
+        int x = (60 / 4) * 60 * gmt;
         if (sign == '+') {
             *time += x;
         } else {

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -1090,6 +1090,7 @@ AT_CellularSMS::sms_info_t *AT_CellularSMS::get_oldest_sms_index()
     return retVal;
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 // if time_string_1 is greater (more fresh date) then return 1, same 0, smaller -1. Error -2
 int AT_CellularSMS::compare_time_strings(const char *time_string_1, const char *time_string_2)
 {
@@ -1113,6 +1114,7 @@ int AT_CellularSMS::compare_time_strings(const char *time_string_1, const char *
 
     return retVal;
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 bool AT_CellularSMS::create_time(const char *time_string, time_t *time)
 {
@@ -1126,7 +1128,7 @@ bool AT_CellularSMS::create_time(const char *time_string, time_t *time)
                &time_struct.tm_hour, &time_struct.tm_min, &time_struct.tm_sec, &sign, &gmt) == kNumberOfElements) {
         *time = mktime(&time_struct);
         // add timezone as seconds. gmt is in quarter of hours.
-        int x = 60 * 60 * gmt * 0.25;
+        int x = (60 * 60 * gmt) / 4;
         if (sign == '+') {
             *time += x;
         } else {

--- a/features/frameworks/unity/source/unity.c
+++ b/features/frameworks/unity/source/unity.c
@@ -8,6 +8,11 @@
 #include "utest/unity_handler.h"
 #include <stddef.h>
 
+#ifndef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
+#define UNITY_EXCLUDE_DOUBLE
+#define UNITY_EXCLUDE_FLOAT
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
+
 /* If omitted from header, declare overrideable prototypes here so they're ready for use */
 #ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
 int UNITY_OUTPUT_CHAR(int);

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -627,6 +627,7 @@ protected:
     uint8_t verify_link_ADR_req(verify_adr_params_t *verify_params, int8_t *dr,
                                 int8_t *tx_pow, uint8_t *nb_rep);
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
     /**
      * Computes the RX window timeout and the RX window offset.
      */
@@ -635,11 +636,22 @@ protected:
                               uint32_t *window_length, uint32_t *window_length_ms,
                               int32_t *window_offset,
                               uint8_t phy_dr);
+#else
+    void get_rx_window_params(int t_symbol, uint8_t min_rx_symbols,
+                              int rx_error, int wakeup_time,
+                              uint32_t *window_length, uint32_t *window_length_ms,
+                              int32_t *window_offset,
+                              uint8_t phy_dr);                              
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
     /**
      * Computes the txPower, based on the max EIRP and the antenna gain.
      */
     int8_t compute_tx_power(int8_t txPowerIndex, float maxEirp, float antennaGain);
+#else
+    int8_t compute_tx_power(int8_t txPowerIndex, int maxEirp, int antennaGain);
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
     /**
      * Provides a random number in the range provided.
@@ -667,12 +679,12 @@ private:
     /**
      * Computes the symbol time for LoRa modulation.
      */
-    float compute_symb_timeout_lora(uint8_t phy_dr, uint32_t bandwidth);
+    int compute_symb_timeout_lora(uint8_t phy_dr, uint32_t bandwidth);
 
     /**
      * Computes the symbol time for FSK modulation.
      */
-    float compute_symb_timeout_fsk(uint8_t phy_dr);
+    int compute_symb_timeout_fsk(uint8_t phy_dr);
 
 protected:
     LoRaRadio *_radio;

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_bootstrap.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_bootstrap.c
@@ -923,6 +923,7 @@ void thread_interface_init(protocol_interface_info_entry_t *cur)
 
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 static void thread_interface_bootsrap_mode_init(protocol_interface_info_entry_t *cur)
 {
     thread_routing_reset(&cur->thread_info->routing);
@@ -973,6 +974,7 @@ static void thread_interface_bootsrap_mode_init(protocol_interface_info_entry_t 
 
     cur->thread_info->thread_attached_state = THREAD_STATE_NETWORK_DISCOVER;
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 int8_t thread_bootsrap_event_trig(thread_bootsrap_event_type_e event_type, int8_t Id, arm_library_event_priority_e priority)
 {

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_management_server.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_management_server.c
@@ -721,6 +721,7 @@ static void energy_scan_confirm_cb(int8_t if_id, const mlme_scan_conf_t *conf)
     }
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 void thread_energy_scan_timeout_cb(void *arg)
 {
     link_configuration_s *linkConfiguration;
@@ -775,6 +776,7 @@ void thread_energy_scan_timeout_cb(void *arg)
         s->mac_api->mlme_req(s->mac_api, MLME_SCAN, &req);
     }
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 
 static void thread_panid_scan_timeout_cb(void *arg)

--- a/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_mle_message_handler.c
+++ b/features/nanostack/sal-stack-nanostack/source/6LoWPAN/Thread/thread_mle_message_handler.c
@@ -66,7 +66,9 @@ static void thread_parse_accept(protocol_interface_info_entry_t *cur, mle_messag
 static void thread_parse_annoucement(protocol_interface_info_entry_t *cur, mle_message_t *mle_msg);
 static void thread_parse_data_response(protocol_interface_info_entry_t *cur, mle_message_t *mle_msg, uint8_t linkMargin);
 static void thread_host_child_update_request_process(protocol_interface_info_entry_t *cur, mle_message_t *mle_msg, uint8_t linkMargin);
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 static void thread_parse_child_update_response(protocol_interface_info_entry_t *cur, mle_message_t *mle_msg, mle_security_header_t *security_headers, uint8_t linkMargin);
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 /* Public functions */
 void thread_general_mle_receive_cb(int8_t interface_id, mle_message_t *mle_msg, mle_security_header_t *security_headers)
@@ -824,6 +826,7 @@ static void thread_host_child_update_request_process(protocol_interface_info_ent
     }
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 static void thread_parse_child_update_response(protocol_interface_info_entry_t *cur, mle_message_t *mle_msg, mle_security_header_t *security_headers, uint8_t linkMargin)
 {
     uint8_t mode;
@@ -907,5 +910,6 @@ static void thread_parse_child_update_response(protocol_interface_info_entry_t *
     mac_data_poll_protocol_poll_mode_decrement(cur);
 
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 #endif

--- a/features/nanostack/sal-stack-nanostack/source/Service_Libs/fhss/fhss_ws.c
+++ b/features/nanostack/sal-stack-nanostack/source/Service_Libs/fhss/fhss_ws.c
@@ -323,6 +323,7 @@ static void fhss_event_timer_cb(int8_t timer_id, uint16_t slots)
     }
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 static uint32_t fhss_ws_calculate_ufsi(fhss_structure_t *fhss_structure, uint32_t tx_time)
 {
     uint8_t dwell_time = fhss_structure->ws->fhss_configuration.fhss_uc_dwell_interval;
@@ -345,6 +346,7 @@ static uint32_t fhss_ws_calculate_ufsi(fhss_structure_t *fhss_structure, uint32_
     }
     return own_floor((float)(ms_since_seq_start * DEF_2E24) / (seq_length * dwell_time));
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 static uint32_t fhss_ws_calculate_broadcast_interval_offset(fhss_structure_t *fhss_structure, uint32_t tx_time)
 {
@@ -362,6 +364,7 @@ static uint32_t fhss_ws_calculate_broadcast_interval_offset(fhss_structure_t *fh
     return (broadcast_interval - remaining_time_ms) + time_to_tx;
 }
 
+#ifdef MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 static uint16_t fhss_ws_calculate_destination_slot(fhss_ws_neighbor_timing_info_t *neighbor_timing_info, uint32_t tx_time)
 {
     uint_fast24_t ufsi = neighbor_timing_info->uc_timing_info.ufsi;
@@ -374,6 +377,7 @@ static uint16_t fhss_ws_calculate_destination_slot(fhss_ws_neighbor_timing_info_
     uint32_t dest_ms_since_seq_start = own_ceil((float)((uint64_t)ufsi * seq_length * dwell_time) / DEF_2E24);
     return (own_floor(((float)(US_TO_MS(tx_time - ufsi_timestamp) + dest_ms_since_seq_start) / dwell_time)) % seq_length);
 }
+#endif // MBED_CONF_TARGET_ENABLE_FLOATING_POINT
 
 static uint32_t fhss_ws_get_sf_timeout_callback(fhss_structure_t *fhss_structure)
 {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -51,6 +51,10 @@
             "init-us-ticker-at-boot": {
                 "help": "Initialize the microsecond ticker at boot rather than on first use, and leave it initialized. This speeds up wait_us in particular.",
                 "value": false
+            },
+            "enable-floating-point": {
+                "help": "Enable floating point usage within Mbed-OS. Possible values are true or null",
+                "value": true
             }
         }
     },


### PR DESCRIPTION
### Description
## **This PR is not intended to be merged!! It only exists to allow Mbed-OS core team members to review prior to raising a public facing PR.**

The changes remove the inclusion of `__aeabi_xxxx` symbols in the map file.
This is done using the following techniques:
* Use a macro to exclude code that include floating point functions (of the form `__aeabi_xxxx()`).
* Provide alternative Public and Protected API functions that return/accept integers. Private functions are simply changed to use integer instead of floating points.
* Usage of literal floating point values have been replaced with integer values where it made sense.

PDMC builds successfully with the macro defined or not.

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes
To fully remove the usage of floating point functions in Mbed OS when building PDMC, minimal printf usage of float also needs to be turned off in https://github.com/hugueskamba/mbed-os/blob/7d715ac05de43608692e6ce79374a553fa7ba24a/features/minimal-printf/mbed_lib.json or by overriding it in `mbed_app.json`.
<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
