### PR TITLE
mbed-retarget: Make filehandles optional to reduce code size

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -16,6 +16,11 @@
             "value": false
         },
 
+        "stdio-minimal-console-only": {
+            "help": "(Applies if target.console-uart is true.) Enable this instead of `stdio-buffered-serial` if filehandles are not required to access the serial interface as console to only to print.",
+            "value": false
+        },
+
         "stdio-baud-rate": {
             "help": "(Applies if target.console-uart is true.) Baud rate for stdio",
             "value": 9600

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -586,6 +586,10 @@ extern "C" {
     long telldir(DIR *);
     void seekdir(DIR *, long);
     int mkdir(const char *name, mode_t n);
+#if MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
+    ssize_t minimal_console_write(const void *buffer, size_t length);
+    ssize_t minimal_console_read(void *buffer, size_t length);
+#endif // MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
 #if __cplusplus
 }; // extern "C"
 

--- a/platform/source/mbed_retarget.cpp
+++ b/platform/source/mbed_retarget.cpp
@@ -104,20 +104,24 @@ extern const char __stderr_name[] = "/stderr";
 unsigned char *mbed_heap_start = 0;
 uint32_t mbed_heap_size = 0;
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 /* newlib has the filehandle field in the FILE struct as a short, so
  * we can't just return a Filehandle* from _open and instead have to
  * put it in a filehandles array and return the index into that array
  */
 static FileHandle *filehandles[OPEN_MAX] = { FILE_HANDLE_RESERVED, FILE_HANDLE_RESERVED, FILE_HANDLE_RESERVED };
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 static char stdio_in_prev[OPEN_MAX];
 static char stdio_out_prev[OPEN_MAX];
 static SingletonPtr<PlatformMutex> filehandle_mutex;
+
 
 namespace mbed {
 void mbed_set_unbuffered_stream(std::FILE *_file);
 
 void remove_filehandle(FileHandle *file)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     filehandle_mutex->lock();
     /* Remove all open filehandles for this */
     for (unsigned int fh_i = 0; fh_i < sizeof(filehandles) / sizeof(*filehandles); fh_i++) {
@@ -126,6 +130,7 @@ void remove_filehandle(FileHandle *file)
         }
     }
     filehandle_mutex->unlock();
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 }
 
@@ -133,6 +138,7 @@ void remove_filehandle(FileHandle *file)
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 /* Private FileHandle to implement backwards-compatible functionality of
  * direct HAL serial access for default stdin/stdout/stderr.
  * This is not a particularly well-behaved FileHandle for a stream, which
@@ -208,8 +214,65 @@ short DirectSerial::poll(short events) const
     }
     return revents;
 }
+#else
+class MinimalSerial {
+public:
+    MinimalSerial(PinName tx, PinName rx, int baud);
+    virtual ssize_t write(const void *buffer, size_t size);
+    virtual ssize_t read(void *buffer, size_t size);
+};
+
+MinimalSerial::MinimalSerial(PinName tx, PinName rx, int baud)
+{
+    if (stdio_uart_inited) {
+        return;
+    }
+
+    serial_init(&stdio_uart, tx, rx);
+    serial_baud(&stdio_uart, baud);
+#if   CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTS
+    serial_set_flow_control(&stdio_uart, FlowControlRTS, STDIO_UART_RTS, NC);
+#elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_CTS
+    serial_set_flow_control(&stdio_uart, FlowControlCTS, NC, STDIO_UART_CTS);
+#elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTSCTS
+    serial_set_flow_control(&stdio_uart, FlowControlRTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
+#endif
+}
+
+ssize_t MinimalSerial::write(const void *buffer, size_t size)
+{
+    const unsigned char *buf = static_cast<const unsigned char *>(buffer);
+    for (size_t i = 0; i < size; i++) {
+        serial_putc(&stdio_uart, buf[i]);
+    }
+    return size;
+}
+
+ssize_t MinimalSerial::read(void *buffer, size_t size)
+{
+    unsigned char *buf = static_cast<unsigned char *>(buffer);
+    if (size == 0) {
+        return 0;
+    }
+    buf[0] = serial_getc(&stdio_uart);
+    return 1;
+}
+
+/* Locate the default console */
+static MinimalSerial *get_minimal_console()
+{
+    static MinimalSerial console(
+        STDIO_UART_TX,
+        STDIO_UART_RX,
+        MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+    );
+
+    return &console;
+}
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 #endif
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 class Sink : public FileHandle {
 public:
     virtual ssize_t write(const void *buffer, size_t size);
@@ -391,9 +454,11 @@ static int reserve_filehandle()
 
     return fh_i;
 }
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 
 int mbed::bind_to_fd(FileHandle *fh)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     int fildes = reserve_filehandle();
     if (fildes < 0) {
         return fildes;
@@ -404,10 +469,14 @@ int mbed::bind_to_fd(FileHandle *fh)
     stdio_out_prev[fildes] = 0;
 
     return fildes;
+#else
+    return -1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
 static int unbind_from_fd(int fd, FileHandle *fh)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     if (filehandles[fd] == fh) {
         filehandles[fd] = NULL;
         return 0;
@@ -415,7 +484,11 @@ static int unbind_from_fd(int fd, FileHandle *fh)
         errno = EBADF;
         return -1;
     }
+#else
+    return -1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
+
 
 #ifndef __IAR_SYSTEMS_ICC__
 /* IAR provides fdopen itself */
@@ -469,6 +542,7 @@ std::FILE *fdopen(FileHandle *fh, const char *mode)
  * */
 extern "C" FILEHANDLE PREFIX(_open)(const char *name, int openflags)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
 #if !defined(MBED_CONF_RTOS_PRESENT)
     // valid only for mbed 2
@@ -516,8 +590,13 @@ extern "C" FILEHANDLE PREFIX(_open)(const char *name, int openflags)
     }
 #endif
     return open(name, openflags_to_posix(openflags));
+#else
+    // Everything goes to the same output
+    return 1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 extern "C" int open(const char *name, int oflag, ...)
 {
     int fildes = reserve_filehandle();
@@ -554,12 +633,18 @@ extern "C" int open(const char *name, int oflag, ...)
 
     return fildes;
 }
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 
 extern "C" int PREFIX(_close)(FILEHANDLE fh)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     return close(fh);
+#else
+    return 0;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 extern "C" int close(int fildes)
 {
     FileHandle *fhc = mbed_file_handle(fildes);
@@ -577,6 +662,7 @@ extern "C" int close(int fildes)
         return 0;
     }
 }
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 
 static bool convert_crlf(int fd)
 {
@@ -588,6 +674,7 @@ static bool convert_crlf(int fd)
     return false;
 #endif
 }
+
 
 #if defined(__ICCARM__)
 extern "C" size_t    __write(int        fh, const unsigned char *buffer, size_t length)
@@ -673,7 +760,7 @@ finish:
 
 extern "C" ssize_t write(int fildes, const void *buf, size_t length)
 {
-
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     FileHandle *fhc = mbed_file_handle(fildes);
     if (fhc == NULL) {
         errno = EBADF;
@@ -681,6 +768,13 @@ extern "C" ssize_t write(int fildes, const void *buf, size_t length)
     }
 
     ssize_t ret = fhc->write(buf, length);
+#else
+    if (fildes != STDOUT_FILENO && fildes != STDERR_FILENO){
+        return EBADF;
+    }
+
+    ssize_t ret = minimal_console_write(buf, length);
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     if (ret < 0) {
         errno = -ret;
         return -1;
@@ -688,6 +782,20 @@ extern "C" ssize_t write(int fildes, const void *buf, size_t length)
         return ret;
     }
 }
+
+#if MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
+/* Write the contents of a buffer to a serial interface */
+MBED_WEAK ssize_t minimal_console_write(const void *buffer, size_t length)
+{
+    MinimalSerial *mc = get_minimal_console();
+    if (mc == nullptr) {
+        errno = EBADF;
+        return -1;
+    }
+
+    return mc->write(buffer, length);
+}
+#endif // MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
 
 #if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
 extern "C" void PREFIX(_exit)(int return_code)
@@ -766,15 +874,26 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 #endif
 }
 
+
 extern "C" ssize_t read(int fildes, void *buf, size_t length)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     FileHandle *fhc = mbed_file_handle(fildes);
+
     if (fhc == NULL) {
         errno = EBADF;
         return -1;
     }
 
     ssize_t ret = fhc->read(buf, length);
+#else
+    if (fildes != STDOUT_FILENO && fildes != STDERR_FILENO){
+        return EBADF;
+    }
+
+    ssize_t ret = minimal_console_read(buf, length);
+#endif //!(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
+
     if (ret < 0) {
         errno = -ret;
         return -1;
@@ -783,6 +902,19 @@ extern "C" ssize_t read(int fildes, void *buf, size_t length)
     }
 }
 
+#if MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
+/* Read the serial interface and store the content to a buffer */
+MBED_WEAK ssize_t minimal_console_read(void *buffer, size_t length)
+{
+    MinimalSerial *mc = get_minimal_console();
+    if (mc == nullptr) {
+        errno = EBADF;
+        return -1;
+    }
+
+    return mc->read(buffer, length);
+}
+#endif // MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
 
 #ifdef __ARMCC_VERSION
 extern "C" int PREFIX(_istty)(FILEHANDLE fh)
@@ -795,6 +927,7 @@ extern "C" int _isatty(FILEHANDLE fh)
 
 extern "C" int isatty(int fildes)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     FileHandle *fhc = mbed_file_handle(fildes);
     if (fhc == NULL) {
         errno = EBADF;
@@ -808,6 +941,10 @@ extern "C" int isatty(int fildes)
     } else {
         return tty;
     }
+#else
+    // Is not attached to an interactive device
+    return 1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
 extern "C"
@@ -819,6 +956,7 @@ long __lseek(int fh, long offset, int whence)
 int _lseek(FILEHANDLE fh, int offset, int whence)
 #endif
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 #if defined(__ARMCC_VERSION)
     int whence = SEEK_SET;
 #endif
@@ -832,8 +970,13 @@ int _lseek(FILEHANDLE fh, int offset, int whence)
         return -1;
     }
     return off;
+#else
+    // Not supported
+    return -1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 extern "C" off_t lseek(int fildes, off_t offset, int whence)
 {
     FileHandle *fhc = mbed_file_handle(fildes);
@@ -873,9 +1016,11 @@ extern "C" int PREFIX(_ensure)(FILEHANDLE fh)
     return fsync(fh);
 }
 #endif
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 
 extern "C" int fsync(int fildes)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     FileHandle *fhc = mbed_file_handle(fildes);
     if (fhc == NULL) {
         errno = EBADF;
@@ -889,11 +1034,15 @@ extern "C" int fsync(int fildes)
     } else {
         return 0;
     }
+#else
+    return -1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
 #ifdef __ARMCC_VERSION
 extern "C" long PREFIX(_flen)(FILEHANDLE fh)
 {
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     FileHandle *fhc = mbed_file_handle(fh);
     if (fhc == NULL) {
         errno = EBADF;
@@ -910,6 +1059,10 @@ extern "C" long PREFIX(_flen)(FILEHANDLE fh)
         return -1;
     }
     return size;
+#else
+    // Not supported
+    return -1;
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
 // Do not compile this code for TFM secure target
@@ -983,7 +1136,7 @@ extern "C" __value_in_regs struct __initial_stackheap __user_setup_stackheap(uin
 
 #endif
 
-
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 #if !defined(__ARMCC_VERSION) && !defined(__ICCARM__)
 extern "C" int _fstat(int fh, struct stat *st)
 {
@@ -1060,6 +1213,7 @@ extern "C" int poll(struct pollfd fds[], nfds_t nfds, int timeout)
     }
     return ret;
 }
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 
 namespace std {
 extern "C" int remove(const char *path)


### PR DESCRIPTION
### Description

The retarget code allocates an array of `FileHandle*` for console and file
handling (filehandles). A tiny target only needs a console (putc/getc).
There is no need for file handling.
The POSIX layer and the array of `FileHandle*` is not required for small
targets that only need a console ; this code should be optionally compiled
out if the configuration parameter `platform.stdio-minimal-console-only` is
selected instead of `platform-stdio-buffered-serial`.

See below sizes obtained with various configurations when building `mbed-os-example-blinky` with the following command line: `mbed compile -t arm -m k64f`

Use `class UARTSerial`
`target.console-uart = true`
`platform.stdio-buffered-serial = true`
`platform.stdio-minimal-console-only = false`
```
Total Static RAM memory (data + bss): 206958(+924) bytes
Total Flash memory (text + data): 52707(+3568) bytes
```

Use `class DirectSerial`
`target.console-uart = true`
`platform.stdio-buffered-serial = false`
`platform.stdio-minimal-console-only = false`
```
Total Static RAM memory (data + bss): 206034(-924) bytes
Total Flash memory (text + data): 49139(-3568) bytes
```

Use `class MinimalSerial`
`target.console-uart = true`
`platform.stdio-buffered-serial = false`
`platform.stdio-minimal-console-only = true`
```
Total Static RAM memory (data + bss): 205882(+0) bytes
Total Flash memory (text + data): 47641(+0) bytes
```

Use `class Sink`
`target.console-uart = true`
`platform.stdio-buffered-serial = false`
`platform.stdio-minimal-console-only = true`
```
Total Static RAM memory (data + bss): 205842(-360) bytes
Total Flash memory (text + data): 46633(-2522) bytes
```

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
