### PR TITLE
mbed_retarget: Add an internal class to provide basic console functionality

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -16,6 +16,11 @@
             "value": false
         },
 
+        "stdio-minimal-console-only": {
+            "help": "(Applies if target.console-uart is true. Ignores stdio-buffered-serial) Creates a console for basic unbuffered I/O operations. Enable if your application does not require file handles to access the serial interface.",
+            "value": true
+        },
+
         "stdio-baud-rate": {
             "help": "(Applies if target.console-uart is true.) Baud rate for stdio",
             "value": 9600

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -94,6 +94,7 @@ namespace mbed {
 class FileHandle;
 class DirHandle;
 
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 /** Targets may implement this to change stdin, stdout, stderr.
  *
  * If the application hasn't provided mbed_override_console, this is called
@@ -179,6 +180,7 @@ FileHandle *mbed_override_console(int fd);
  *           possible if it's not open with current implementation).
  */
 FileHandle *mbed_file_handle(int fd);
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 }
 
 typedef mbed::DirHandle DIR;
@@ -559,6 +561,7 @@ struct pollfd {
 #if __cplusplus
 extern "C" {
 #endif
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     int open(const char *path, int oflag, ...);
 #ifndef __IAR_SYSTEMS_ICC__ /* IAR provides fdopen itself */
 #if __cplusplus
@@ -567,8 +570,10 @@ extern "C" {
     FILE *fdopen(int fildes, const char *mode);
 #endif
 #endif
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     ssize_t write(int fildes, const void *buf, size_t nbyte);
     ssize_t read(int fildes, void *buf, size_t nbyte);
+#if !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
     off_t lseek(int fildes, off_t offset, int whence);
     int ftruncate(int fildes, off_t length);
     int isatty(int fildes);
@@ -586,6 +591,7 @@ extern "C" {
     long telldir(DIR *);
     void seekdir(DIR *, long);
     int mkdir(const char *name, mode_t n);
+#endif // !(MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY)
 #if __cplusplus
 }; // extern "C"
 
@@ -618,6 +624,34 @@ std::FILE *fdopen(mbed::FileHandle *fh, const char *mode);
  *  @return         an integer file descriptor, or negative if no descriptors available
  */
 int bind_to_fd(mbed::FileHandle *fh);
+
+#if MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
+/** Targets may implement this to override how to write to the console.
+ *
+ * If the target hasn't provided minimal_console_write, this is called
+ * to give the target a chance to specify a serial access to the console.
+ *
+ * If this is not provided, the console will be MinimalConsole
+ *
+ *  @param buffer   The buffer to write from
+ *  @param length   The number of bytes to write
+ *  @return         The number of bytes written
+ */
+ssize_t minimal_console_write(const void *buffer, size_t length);
+
+/** Targets may implement this to override how to read from the console.
+ *
+ * If the target hasn't provided minimal_console_read, this is called
+ * to give the target a chance to specify a serial access to the console.
+ *
+ * If this is not provided, the console will be MinimalConsole
+ *
+ *  @param buffer   The buffer to read in
+ *  @param length   The number of bytes to read
+ *  @return         0 length is zero or buffer is nullptr, 1 an attempt to read was made
+ */
+ssize_t minimal_console_read(void *buffer, size_t length);
+#endif // MBED_CONF_PLATFORM_STDIO_MINIMAL_CONSOLE_ONLY
 
 } // namespace mbed
 


### PR DESCRIPTION
### Description
The retarget code allocates an array of FileHandle* for console and file
handling (filehandles). A tiny target only needs a console (putc/getc).
There is no need for file handling.

The POSIX layer and the array of FileHandle* is not required for small
targets that only need a console ; this code is optionally compiled
out if the configuration parameter platform.stdio-minimal-console-only is
set to `"true"`.

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->


### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
`mbed-os-example-blinky` (`master`) for `K64F`

Toolchain `GCC_ARM`
```
Total Static RAM memory (data + bss): 12096 bytes
Total Flash memory (text + data): 66428 bytes
```

Toolchain `ARM`
```
Total Static RAM memory (data + bss): 205879 bytes
Total Flash memory (text + data): 47625 bytes
```